### PR TITLE
More options for substitution

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="PartialSubstitution.cs" />
     <Compile Include="TestForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/AssemblyToProcess/PartialSubstitution.cs
+++ b/AssemblyToProcess/PartialSubstitution.cs
@@ -1,0 +1,39 @@
+﻿using Substitute;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AssemblyToProcess
+{
+    #region External Stuff
+    public abstract class ExternalClass
+    {
+        public abstract ExternalDataProvider GetDataProvider();
+
+        public string GetText() => GetDataProvider().GetText();
+    }
+
+    public class ExternalDataProvider
+    {
+        public virtual string GetText() => "Test";
+    }
+    #endregion
+
+    [Substitute(typeof(ExternalDataProvider), typeof(QuotingDataProvider), DoNotChangeSignature = true)]
+    public class SubstitutionSubjectClass : ExternalClass
+    {
+        public override ExternalDataProvider GetDataProvider() => new ExternalDataProvider();
+
+        [Substitute(typeof(ExternalDataProvider), typeof(QuotingDataProvider), Disable = true)]
+        public ExternalDataProvider GetOriginalDataProvider() => new ExternalDataProvider();
+
+        public string GetOriginalText() => GetOriginalDataProvider().GetText();
+    }
+
+    public class QuotingDataProvider : ExternalDataProvider
+    {
+        public override string GetText() => "\"" + base.GetText() + "\"";
+    }
+}

--- a/Substitute.Fody/ExtensionMethods.cs
+++ b/Substitute.Fody/ExtensionMethods.cs
@@ -54,18 +54,10 @@ namespace Substitute
                         isDisable = (bool)prop.Argument.Value;
 
                     if (prop.Name == "DoNotChangeSignature")
-                    {
-                        var value = (bool?)prop.Argument.Value;
-                        if (value.HasValue)
-                            currentParameters._DoNotChangeSignature = value;
-                    }
+                        currentParameters._DoNotChangeSignature = (bool)prop.Argument.Value;
 
                     if (prop.Name == "KeepBaseMemberSignature")
-                    {
-                        var value = (bool?)prop.Argument.Value;
-                        if (value.HasValue)
-                            currentParameters._DoNotChangeSignature = value;
-                    }
+                        currentParameters._KeepBaseMemberSignature = (bool)prop.Argument.Value;
                 }
 
                 if (isDisable)

--- a/Substitute.Fody/ModuleWeaver.cs
+++ b/Substitute.Fody/ModuleWeaver.cs
@@ -15,7 +15,7 @@ namespace Substitute
     {
         public override void Execute()
         {
-            ModuleDefinition.Weave(this);
+            ModuleDefinition.Weave(this, Parameters.GetFromConfig(Config));
             ModuleDefinition.RemoveReferences(this);
         }
 

--- a/Substitute.Fody/Parameters.cs
+++ b/Substitute.Fody/Parameters.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Substitute
+{
+    internal struct Parameters : IEquatable<Parameters>
+    {
+        internal bool? _DoNotChangeSignature;
+        internal bool? _KeepBaseMemberSignature;
+
+        /// <summary>
+        /// If this option is enabled, the substitution will only be applied to the method bodies,
+        /// but not to any signature.
+        /// </summary>
+        internal bool DoNotChangeSignature => _DoNotChangeSignature.GetValueOrDefault(false);
+
+        /// <summary>
+        /// If this option is enabled, the signatures of a member overwriting another member that is not subject to the
+        /// substitution, will be kept.
+        /// </summary>
+        internal bool KeepBaseMemberSignature => _KeepBaseMemberSignature.GetValueOrDefault(false);
+
+        internal static Parameters GetFromConfig(XElement config)
+        {
+            var result = new Parameters();
+
+            if (config != null)
+            {
+                var doNotChangeValue = config.Attribute(nameof(DoNotChangeSignature))?.Value;
+                if (doNotChangeValue != null)
+                    result._DoNotChangeSignature = XmlConvert.ToBoolean(doNotChangeValue);
+
+                var keepBaseMembersValue = config.Attribute(nameof(KeepBaseMemberSignature))?.Value;
+                if (keepBaseMembersValue != null)
+                    result._KeepBaseMemberSignature = XmlConvert.ToBoolean(keepBaseMembersValue);
+            }
+
+            return result;
+        }
+
+        internal Parameters Apply(Parameters parameters)
+        {
+            if (parameters._DoNotChangeSignature.HasValue)
+                _DoNotChangeSignature = parameters._DoNotChangeSignature;
+
+            if (parameters._KeepBaseMemberSignature.HasValue)
+                _KeepBaseMemberSignature = parameters._KeepBaseMemberSignature;
+
+            return parameters;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Parameters && Equals((Parameters)obj);
+        }
+
+        public bool Equals(Parameters other) =>
+            Nullable.Equals(_DoNotChangeSignature, other._DoNotChangeSignature) &&
+                Nullable.Equals(_KeepBaseMemberSignature, other._KeepBaseMemberSignature);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return _DoNotChangeSignature.GetHashCode() * 23 + _KeepBaseMemberSignature.GetHashCode();
+            }
+        }
+
+        public static bool operator ==(Parameters parameters1, Parameters parameters2)
+        {
+            return parameters1.Equals(parameters2);
+        }
+
+        public static bool operator !=(Parameters parameters1, Parameters parameters2)
+        {
+            return !(parameters1 == parameters2);
+        }
+    }
+}

--- a/Substitute.Fody/SubstitutionTarget.cs
+++ b/Substitute.Fody/SubstitutionTarget.cs
@@ -1,0 +1,49 @@
+﻿using JetBrains.Annotations;
+using Mono.Cecil;
+using System;
+using System.Collections.Generic;
+
+namespace Substitute
+{
+    internal sealed class SubstitutionTarget : IEquatable<SubstitutionTarget>
+    {
+        [NotNull]
+        internal TypeDefinition TargetType { get; }
+
+        [NotNull]
+        internal Parameters Parameters { get; }
+
+        internal SubstitutionTarget([NotNull] TypeDefinition targetType, Parameters parameters)
+        {
+            TargetType = targetType;
+            Parameters = parameters;
+        }
+
+        public override bool Equals(object obj) => Equals(obj as SubstitutionTarget);
+
+        public bool Equals(SubstitutionTarget other)
+        {
+            if (other == null) return false;
+
+            return TypeReferenceEqualityComparer.Equals(TargetType, other.TargetType) && Parameters.Equals(other.Parameters);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return TypeReferenceEqualityComparer.GetHashCode(TargetType) * 23 + Parameters.GetHashCode();
+            }
+        }
+
+        public static bool operator ==(SubstitutionTarget target1, SubstitutionTarget target2)
+        {
+            return EqualityComparer<SubstitutionTarget>.Default.Equals(target1, target2);
+        }
+
+        public static bool operator !=(SubstitutionTarget target1, SubstitutionTarget target2)
+        {
+            return !(target1 == target2);
+        }
+    }
+}

--- a/Substitute.Fody/TypeReferenceEqualityComparer.cs
+++ b/Substitute.Fody/TypeReferenceEqualityComparer.cs
@@ -7,24 +7,22 @@ using Mono.Cecil;
 
 namespace Substitute
 {
-    internal class TypeReferenceEqualityComparer : IEqualityComparer<TypeReference>
+    internal sealed class TypeReferenceEqualityComparer : IEqualityComparer<TypeReference>
     {
         private TypeReferenceEqualityComparer()
         {
         }
 
         [NotNull]
-        public static IEqualityComparer<TypeReference> Default { get; } = new TypeReferenceEqualityComparer();
+        internal static IEqualityComparer<TypeReference> Default { get; } = new TypeReferenceEqualityComparer();
 
-        public bool Equals(TypeReference x, TypeReference y)
-        {
-            return GetKey(x) == GetKey(y);
-        }
+        internal static bool Equals([CanBeNull] TypeReference x, [CanBeNull] TypeReference y) => Default.Equals(x, y);
 
-        public int GetHashCode([CanBeNull] TypeReference obj)
-        {
-            return GetKey(obj)?.GetHashCode() ?? 0;
-        }
+        internal static int GetHashCode([CanBeNull] TypeReference obj) => Default.GetHashCode(obj);
+
+        bool IEqualityComparer<TypeReference>.Equals(TypeReference x, TypeReference y) => GetKey(x) == GetKey(y);
+
+        int IEqualityComparer<TypeReference>.GetHashCode([CanBeNull] TypeReference obj) => GetKey(obj)?.GetHashCode() ?? 0;
 
         [CanBeNull]
         private static string GetKey([CanBeNull] TypeReference obj)

--- a/Substitute/SubstituteAttribute.cs
+++ b/Substitute/SubstituteAttribute.cs
@@ -30,13 +30,13 @@ namespace Substitute
         /// If this option is enabled, the substitution will only be applied to the method bodies,
         /// but not to any signature.
         /// </summary>
-        public bool? DoNotChangeSignature { get; set; }
+        public bool DoNotChangeSignature { get; set; }
 
         /// <summary>
         /// If this option is enabled, the signatures of a member overwriting another member that is not subject to the
         /// substitution, will be kept.
         /// </summary>
-        public bool? KeepBaseMemberSignature { get; set; }
+        public bool KeepBaseMemberSignature { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SubstituteAttribute"/> class.

--- a/Substitute/SubstituteAttribute.cs
+++ b/Substitute/SubstituteAttribute.cs
@@ -6,9 +6,38 @@ namespace Substitute
     /// <summary>
     /// Add this attribute to your assembly to substitute one type with another, i.e. all usages of the original type will be replaced by the new type.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    [AttributeUsage(
+        AttributeTargets.Assembly |
+        AttributeTargets.Module |
+        AttributeTargets.Class |
+        AttributeTargets.Interface |
+        AttributeTargets.Struct |
+        AttributeTargets.Event |
+        AttributeTargets.Field |
+        AttributeTargets.Property |
+        AttributeTargets.Method, AllowMultiple = true)]
     public sealed class SubstituteAttribute : Attribute
     {
+        /// <summary>
+        /// If this property is set to true, the specified substitution will be removed from the substitution list.
+        /// </summary>
+        /// <remarks>
+        /// In case a substitution is specified that was never enabled, the attribute will not do anything.
+        /// </remarks>
+        public bool Disable { get; set; } = false;
+
+        /// <summary>
+        /// If this option is enabled, the substitution will only be applied to the method bodies,
+        /// but not to any signature.
+        /// </summary>
+        public bool? DoNotChangeSignature { get; set; }
+
+        /// <summary>
+        /// If this option is enabled, the signatures of a member overwriting another member that is not subject to the
+        /// substitution, will be kept.
+        /// </summary>
+        public bool? KeepBaseMemberSignature { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SubstituteAttribute"/> class.
         /// </summary>

--- a/Tests/FodyTests.cs
+++ b/Tests/FodyTests.cs
@@ -33,6 +33,17 @@ public class FodyTests
     }
 
     [Fact]
+    public void Test1Partial()
+    {
+        var assembly = WeaverHelper.Create("Test1/AssemblyToProcess").Assembly;
+
+        var target = assembly.GetInstance("AssemblyToProcess.SubstitutionSubjectClass");
+
+        Assert.Equal("\"Test\"", target.GetText());
+        Assert.Equal("Test", target.GetOriginalText());
+    }
+
+    [Fact]
     public void Test2()
     {
         var assembly = WeaverHelper.Create("Test2/AssemblyToProcess").Assembly;


### PR DESCRIPTION
This is the PR for issue #2 

It is not done yet, but this is to compare notes, give you an idea how it turns out and to get early input from you in case you don't like where this is heading.

For right now enabling and disabling specific substitutions works on assembly, module, type, field, property and method base. It also allows the disable the substitution of signatures.

The option to skip signature substitution of overwritten members is not done yet. Still working on this, but that is not very easily possible based on the way how the weaver works right now.